### PR TITLE
ci: add GitHub Actions CI workflow with npm audit and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]  # Only run on main branch
+  pull_request:
+    branches: [main]  # Run on PRs to main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check for vulnerabilities
+        run: npm audit --audit-level=high
+
+      - name: Lint
+        run: npx biome check .

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,0 @@
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write


### PR DESCRIPTION
## Summary
- Add CI workflow that runs on pushes to main and PRs
- Runs tests, npm audit (high/critical only), and biome lint
- Add Dependabot for weekly dependency updates
- Remove deprecated claude.yml (permissions only, no workflow)

## Test plan
- [x] CI workflow file created
- [x] Dependabot configuration added
- [x] Old workflow file removed
- [ ] Verify workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)