### PR TITLE
fix(citation-manager): collapse whitespace in heading normalization (Issue #14)

### DIFF
--- a/tools/citation-manager/src/ParsedDocument.ts
+++ b/tools/citation-manager/src/ParsedDocument.ts
@@ -260,7 +260,9 @@ class ParsedDocument {
 			.replace(/\^/g, "")     // Remove caret
 			.replace(/%%/g, "")     // Remove comment markers
 			.replace(/\[\[/g, "")   // Remove wiki open
-			.replace(/\]\]/g, "");  // Remove wiki close
+			.replace(/\]\]/g, "")   // Remove wiki close
+			.replace(/\s+/g, " ")   // Collapse whitespace (matches URL-encoded anchor generation)
+			.trim();
 	}
 
 	/**


### PR DESCRIPTION
ContentExtractor reported "Heading not found" for valid citations because
_normalizeObsidianHeading removed special chars (: | ^ etc.) without
collapsing resulting whitespace gaps. URL-encoded anchors collapse spaces
via \s+ → %20, so decoded anchors had single spaces while normalized
headings retained double spaces, causing mismatch.

Closes #14

https://claude.ai/code/session_01EP8P9d87TwzoCDh93n56G8