### PR TITLE
fix(citation-manager): handle backticks and nested parens in anchor IDs (#27)

### DIFF
--- a/tools/citation-manager/src/core/MarkdownParser/extractLinks.ts
+++ b/tools/citation-manager/src/core/MarkdownParser/extractLinks.ts
@@ -41,8 +41,9 @@ function findPosition(raw: string, lines: string[]): { line: number; column: num
 
 /**
  * Deduplication helper: check if a link was already extracted.
- * Uses multi-property matching to handle variations in encoding/whitespace.
- * Compares: rawPath, anchor, line, column (stricter than fullMatch alone)
+ * Uses position-based matching (line + column) to prevent duplicate extraction
+ * when the token parser and regex fallback extract the same link with different
+ * anchor encodings (e.g., nested parens causing truncation in one extractor).
  */
 function isDuplicateLink(
 	candidate: { rawPath: string | null; anchor: string | null; line: number; column: number },
@@ -50,8 +51,6 @@ function isDuplicateLink(
 ): boolean {
 	return existingLinks.some(
 		l =>
-			l.target.path.raw === candidate.rawPath &&
-			l.target.anchor === candidate.anchor &&
 			l.line === candidate.line &&
 			l.column === candidate.column
 	);
@@ -218,8 +217,8 @@ function extractMarkdownLinksRegex(
 	links: LinkObject[]
 ): void {
 	// Pattern for markdown links: [text](path#anchor)
-	// Permissive anchor pattern allows spaces, colons, parens
-	const linkPattern = /\[([^\]]+)\]\(([^)#]+\.md)(?:#((?:[^()]|\([^)]*\))+))?\)/g;
+	// Permissive anchor pattern allows spaces, colons, parens (supports 2 levels of nesting)
+	const linkPattern = /\[([^\]]+)\]\(([^)#]+\.md)(?:#((?:[^()]|\((?:[^()]|\([^)]*\))*\))+))?\)/g;
 	let match = linkPattern.exec(line);
 	while (match !== null) {
 		const text = match[1] ?? "";
@@ -259,8 +258,8 @@ function extractMarkdownLinksRegex(
 		match = linkPattern.exec(line);
 	}
 
-	// Internal anchor links: [text](#anchor) with permissive anchor
-	const internalAnchorRegex = /\[([^\]]+)\]\(#((?:[^()]|\([^)]*\))+)\)/g;
+	// Internal anchor links: [text](#anchor) with permissive anchor (supports 2 levels of nesting)
+	const internalAnchorRegex = /\[([^\]]+)\]\(#((?:[^()]|\((?:[^()]|\([^)]*\))*\))+)\)/g;
 	match = internalAnchorRegex.exec(line);
 	while (match !== null) {
 		const text = match[1] ?? "";
@@ -300,7 +299,7 @@ function extractMarkdownLinksRegex(
 	}
 
 	// Relative doc links without .md extension: [text](path/to/file#anchor)
-	const relativeDocRegex = /\[([^\]]+)\]\(([^)]*\/[^)#]+)(?:#((?:[^()]|\([^)]*\))+))?\)/g;
+	const relativeDocRegex = /\[([^\]]+)\]\(([^)]*\/[^)#]+)(?:#((?:[^()]|\((?:[^()]|\([^)]*\))*\))+))?\)/g;
 	match = relativeDocRegex.exec(line);
 	while (match !== null) {
 		const filepath = match[2] ?? "";

--- a/tools/citation-manager/test/fixtures/backtick-anchors.md
+++ b/tools/citation-manager/test/fixtures/backtick-anchors.md
@@ -1,0 +1,39 @@
+# Backtick Anchor Test Document
+
+## `hasAnchor(anchorId: string): boolean`
+
+This method checks if an anchor exists.
+
+## `findSimilarAnchors(anchorId: string): string[]`
+
+This method finds similar anchors.
+
+## `validateFile(filePath: string): Promise<ValidationResult>`
+
+This method validates a file.
+
+## `transform(input: T, fn: (item: T) => U): U[]`
+
+Nested parentheses in method signature.
+
+## Internal Links with Backticks (URL-encoded)
+
+- [**`hasAnchor(anchorId: string): boolean`**](#`hasAnchor(anchorId%20string)%20boolean`)
+- [`findSimilarAnchors(anchorId: string): string[]`](#`findSimilarAnchors(anchorId%20string)%20string[]`)
+- [`validateFile(filePath: string): Promise<ValidationResult>`](#`validateFile(filePath%20string)%20Promise%3CValidationResult%3E`)
+
+## Internal Links with Unencoded Special Chars
+
+- [hasAnchor](#hasAnchor(anchorId: string): boolean)
+- [findSimilarAnchors](#findSimilarAnchors(anchorId: string): string[])
+- [`hasAnchor(anchorId: string): boolean`](#hasAnchor(anchorId: string): boolean)
+
+## Internal Links with %28/%29 Encoded Parens
+
+- [hasAnchor method](#hasAnchor%28anchorId%3A%20string%29%3A%20boolean)
+- [`hasAnchor`](#`hasAnchor%28anchorId%3A%20string%29%3A%20boolean`)
+
+## Internal Links with Nested Parentheses
+
+- [`transform`](#`transform(input%20T,%20fn%20(item%20T)%20%3D>%20U)%20U[]`)
+- [transform no-encoding](#`transform(input: T, fn: (item: T) => U): U[]`)

--- a/tools/citation-manager/test/integration/backtick-anchor-links.test.js
+++ b/tools/citation-manager/test/integration/backtick-anchor-links.test.js
@@ -1,0 +1,127 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { createCitationValidator } from "../../src/factories/componentFactory.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, "..", "fixtures");
+
+describe("Internal links with backticks in anchor IDs (Issue #27)", () => {
+	it("should validate all internal links in backtick-anchors fixture without errors", async () => {
+		const validator = createCitationValidator();
+		const testFile = join(fixturesDir, "backtick-anchors.md");
+
+		const result = await validator.validateFile(testFile);
+
+		expect(result.summary.total).toBeGreaterThan(0);
+
+		// No link should have validation errors - all reference valid headings
+		const errorLinks = result.links.filter(
+			(link) => link.validation.status === "error",
+		);
+
+		expect(errorLinks).toEqual([]);
+	});
+
+	it("should not produce duplicate links from regex fallback when token parser succeeds", async () => {
+		const validator = createCitationValidator();
+		const testFile = join(fixturesDir, "backtick-anchors.md");
+
+		const result = await validator.validateFile(testFile);
+
+		// Count links per line - no line should have more than one extracted link
+		const linksByLine = new Map();
+		for (const link of result.links) {
+			if (!linksByLine.has(link.line)) {
+				linksByLine.set(link.line, []);
+			}
+			linksByLine.get(link.line).push(link);
+		}
+
+		for (const [line, links] of linksByLine) {
+			expect(links.length).toBe(1);
+		}
+	});
+
+	it("should correctly extract anchors with nested parentheses", async () => {
+		const validator = createCitationValidator();
+		const testFile = join(fixturesDir, "backtick-anchors.md");
+
+		const result = await validator.validateFile(testFile);
+
+		// Find the nested parens links referencing transform heading
+		const nestedParenLinks = result.links.filter(
+			(link) =>
+				link.target.anchor &&
+				link.target.anchor.includes("transform"),
+		);
+
+		expect(nestedParenLinks.length).toBeGreaterThanOrEqual(2);
+
+		for (const link of nestedParenLinks) {
+			expect(link.validation.status).toBe("valid");
+		}
+	});
+
+	it("should match URL-encoded backtick anchors to heading targets", async () => {
+		const validator = createCitationValidator();
+		const testFile = join(fixturesDir, "backtick-anchors.md");
+
+		const result = await validator.validateFile(testFile);
+
+		// Find links with URL-encoded anchors containing backticks
+		const backtickLinks = result.links.filter(
+			(link) =>
+				link.target.anchor &&
+				link.target.anchor.includes("`"),
+		);
+
+		expect(backtickLinks.length).toBeGreaterThanOrEqual(1);
+
+		for (const link of backtickLinks) {
+			expect(link.validation.status).toBe("valid");
+		}
+	});
+
+	it("should match anchors with %28/%29 encoded parentheses", async () => {
+		const validator = createCitationValidator();
+		const testFile = join(fixturesDir, "backtick-anchors.md");
+
+		const result = await validator.validateFile(testFile);
+
+		// Find links with %28/%29 encoded parens
+		const encodedParenLinks = result.links.filter(
+			(link) =>
+				link.target.anchor &&
+				(link.target.anchor.includes("%28") || link.target.anchor.includes("%29")),
+		);
+
+		expect(encodedParenLinks.length).toBeGreaterThanOrEqual(2);
+
+		for (const link of encodedParenLinks) {
+			expect(link.validation.status).toBe("valid");
+		}
+	});
+
+	it("should handle unencoded special chars in internal anchor links", async () => {
+		const validator = createCitationValidator();
+		const testFile = join(fixturesDir, "backtick-anchors.md");
+
+		const result = await validator.validateFile(testFile);
+
+		// Find links with unencoded colons (raw method signatures)
+		const unencodedLinks = result.links.filter(
+			(link) =>
+				link.target.anchor &&
+				link.target.anchor.includes(":") &&
+				!link.target.anchor.includes("%"),
+		);
+
+		expect(unencodedLinks.length).toBeGreaterThanOrEqual(1);
+
+		for (const link of unencodedLinks) {
+			expect(link.validation.status).toBe("valid");
+		}
+	});
+});


### PR DESCRIPTION
Two fixes for false negatives in citation validation:

1. Upgrade anchor regex to support 2 levels of nested parentheses.
   Method signatures like `fn(arg: (T) => U): U[]` were truncated
   by the old pattern `(?:[^()]|\([^)]*\))+` which only handled
   one level of nesting.

2. Fix dedup to use position-based matching (line + column) instead
   of full property matching. When marked.js token parser extracted
   a link correctly but the regex fallback also matched a truncated
   version, both were kept because their anchors differed.

https://claude.ai/code/session_01PsgbPa22DmMnbx7CFND1tV