### PR TITLE
feat(citation-validator): warn when markdown links point to folders (#46)

### DIFF
--- a/tools/citation-manager/src/CitationValidator.ts
+++ b/tools/citation-manager/src/CitationValidator.ts
@@ -121,6 +121,14 @@ export class CitationValidator {
 		}
 	}
 
+	private isDirectory(path: string): boolean {
+		try {
+			return existsSync(path) && statSync(path).isDirectory();
+		} catch (_error) {
+			return false;
+		}
+	}
+
 	private isObsidianAbsolutePath(path: string): boolean {
 		// Detect Obsidian absolute paths like "0_SoftwareDevelopment/..."
 		return /^[A-Za-z0-9_-]+\//.test(path) && !isAbsolute(path);
@@ -236,7 +244,10 @@ export class CitationValidator {
 		citation: LinkObject,
 		contextFile?: string,
 	): Promise<EnrichedLinkObject> {
-		const result = await this._validateSingleCitationInternal(citation, contextFile);
+		const result = await this._validateSingleCitationInternal(
+			citation,
+			contextFile,
+		);
 
 		// Transform internal result → ValidationMetadata (enrichment pattern)
 		let validation: ValidationMetadata;
@@ -396,6 +407,16 @@ export class CitationValidator {
 			citation.target.path.raw ?? "",
 			sourceFile ?? "",
 		);
+
+		// Check if target resolves to a directory (folder link detection)
+		if (this.isDirectory(standardPath) || this.isDirectory(targetPath)) {
+			return this.createValidationResult(
+				citation,
+				"warning",
+				`Link points to a folder, not a file: ${citation.target.path.raw}`,
+				"Link to a specific file inside the folder (e.g., folder/index.md) or create an index.md in the target folder",
+			);
+		}
 
 		// Check if target file exists
 		if (!existsSync(targetPath)) {

--- a/tools/citation-manager/test/fixtures/folder-link-test.md
+++ b/tools/citation-manager/test/fixtures/folder-link-test.md
@@ -1,0 +1,7 @@
+# Folder Link Test
+
+This file tests folder link detection.
+
+- Valid link: [Target](test-target.md)
+- Folder link with trailing slash: [Subdir](subdir/)
+- Folder link without trailing slash: [Subdir](subdir)

--- a/tools/citation-manager/test/folder-link-detection.test.js
+++ b/tools/citation-manager/test/folder-link-detection.test.js
@@ -1,0 +1,176 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it } from "vitest";
+import { CitationValidator } from "../src/CitationValidator.js";
+import { MarkdownParser } from "../src/core/MarkdownParser/index.js";
+import { ParsedFileCache } from "../src/ParsedFileCache.js";
+import { createCitationValidator } from "../src/factories/componentFactory.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = resolve(__dirname, "fixtures");
+
+describe("Folder link detection (Issue #46)", () => {
+	let validator;
+
+	beforeEach(() => {
+		const fs = { readFileSync };
+		const parser = new MarkdownParser(fs);
+		const cache = new ParsedFileCache(parser);
+		validator = new CitationValidator(cache, null);
+	});
+
+	describe("validateSingleCitation warns on folder links", () => {
+		it("should emit warning for link with trailing slash pointing to directory", async () => {
+			// Given: A link pointing to an existing directory (trailing slash)
+			const folderLink = {
+				linkType: "markdown",
+				scope: "cross-document",
+				anchorType: null,
+				source: { path: { absolute: join(fixturesDir, "valid-citations.md") } },
+				target: {
+					path: {
+						raw: "subdir/",
+						absolute: null,
+						relative: null,
+					},
+					anchor: null,
+				},
+				text: "Subdir",
+				fullMatch: "[Subdir](subdir/)",
+				line: 10,
+				column: 0,
+				extractionMarker: null,
+			};
+
+			const result = await validator.validateSingleCitation(
+				folderLink,
+				join(fixturesDir, "valid-citations.md"),
+			);
+
+			expect(result.validation.status).toBe("warning");
+			expect(result.validation.error).toContain("folder");
+		});
+
+		it("should emit warning for folder link without trailing slash", async () => {
+			// Given: A link pointing to an existing directory (no trailing slash)
+			const folderLink = {
+				linkType: "markdown",
+				scope: "cross-document",
+				anchorType: null,
+				source: { path: { absolute: join(fixturesDir, "valid-citations.md") } },
+				target: {
+					path: {
+						raw: "subdir",
+						absolute: null,
+						relative: null,
+					},
+					anchor: null,
+				},
+				text: "Subdir",
+				fullMatch: "[Subdir](subdir)",
+				line: 10,
+				column: 0,
+				extractionMarker: null,
+			};
+
+			const result = await validator.validateSingleCitation(
+				folderLink,
+				join(fixturesDir, "valid-citations.md"),
+			);
+
+			expect(result.validation.status).toBe("warning");
+			expect(result.validation.error).toContain("folder");
+		});
+
+		it("should suggest linking to a specific file or creating index.md", async () => {
+			// Given: A folder link
+			const folderLink = {
+				linkType: "markdown",
+				scope: "cross-document",
+				anchorType: null,
+				source: { path: { absolute: join(fixturesDir, "valid-citations.md") } },
+				target: {
+					path: {
+						raw: "subdir/",
+						absolute: null,
+						relative: null,
+					},
+					anchor: null,
+				},
+				text: "Subdir",
+				fullMatch: "[Subdir](subdir/)",
+				line: 10,
+				column: 0,
+				extractionMarker: null,
+			};
+
+			const result = await validator.validateSingleCitation(
+				folderLink,
+				join(fixturesDir, "valid-citations.md"),
+			);
+
+			expect(result.validation.status).toBe("warning");
+			// Should provide actionable suggestion
+			expect(result.validation.suggestion).toBeDefined();
+			expect(typeof result.validation.suggestion).toBe("string");
+		});
+
+		it("should not false-positive on legitimate file links", async () => {
+			// Given: A link pointing to an actual file (not a folder)
+			const fileLink = {
+				linkType: "markdown",
+				scope: "cross-document",
+				anchorType: null,
+				source: { path: { absolute: join(fixturesDir, "valid-citations.md") } },
+				target: {
+					path: {
+						raw: "test-target.md",
+						absolute: null,
+						relative: null,
+					},
+					anchor: null,
+				},
+				text: "Target",
+				fullMatch: "[Target](test-target.md)",
+				line: 10,
+				column: 0,
+				extractionMarker: null,
+			};
+
+			const result = await validator.validateSingleCitation(
+				fileLink,
+				join(fixturesDir, "valid-citations.md"),
+			);
+
+			// Should be valid, not a folder warning
+			expect(result.validation.status).toBe("valid");
+		});
+	});
+
+	describe("validateFile integration with folder links", () => {
+		it("should detect folder links in a markdown file and report warnings", async () => {
+			const factoryValidator = createCitationValidator();
+			const testFile = join(fixturesDir, "folder-link-test.md");
+
+			const result = await factoryValidator.validateFile(testFile);
+
+			// Should have warnings for folder links
+			expect(result.summary.warnings).toBeGreaterThan(0);
+
+			const warningLinks = result.links.filter(
+				(link) => link.validation.status === "warning",
+			);
+			expect(warningLinks.length).toBeGreaterThan(0);
+
+			// At least one warning should mention "folder"
+			const folderWarning = warningLinks.find(
+				(link) =>
+					link.validation.status !== "valid" &&
+					link.validation.error?.toLowerCase().includes("folder"),
+			);
+			expect(folderWarning).toBeTruthy();
+		});
+	});
+});


### PR DESCRIPTION
Detect directory targets in cross-document link validation and emit
warnings with actionable suggestions instead of silent acceptance.

https://claude.ai/code/session_01EgYBw37yuESEsjnfW2FUv9